### PR TITLE
Update Unity package lock metadata

### DIFF
--- a/CursorUnityTool/Packages/com.rankupgames.unity-cursor-toolkit/bunfig.toml.meta
+++ b/CursorUnityTool/Packages/com.rankupgames.unity-cursor-toolkit/bunfig.toml.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: 960389d36fcc34a4c82e9245431ad649
-DefaultImporter:
-  externalObjects: {}
-  userData:
-  assetBundleName:
-  assetBundleVariant:

--- a/CursorUnityTool/Packages/com.rankupgames.unity-cursor-toolkit/pnpm-workspace.yaml.meta
+++ b/CursorUnityTool/Packages/com.rankupgames.unity-cursor-toolkit/pnpm-workspace.yaml.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: db7a1b978e7db49dab5ca23bf5f0d794
-TextScriptImporter:
-  externalObjects: {}
-  userData:
-  assetBundleName:
-  assetBundleVariant:

--- a/CursorUnityTool/Packages/packages-lock.json
+++ b/CursorUnityTool/Packages/packages-lock.json
@@ -8,13 +8,6 @@
         "com.unity.nuget.newtonsoft-json": "3.2.1"
       }
     },
-    "com.unity.nuget.newtonsoft-json": {
-      "version": "3.2.1",
-      "depth": 1,
-      "source": "registry",
-      "dependencies": {},
-      "url": "https://packages.unity.com"
-    },
     "com.unity.ai.navigation": {
       "version": "2.0.12",
       "depth": 0,
@@ -105,6 +98,13 @@
     "com.unity.nuget.mono-cecil": {
       "version": "1.11.6",
       "depth": 3,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.nuget.newtonsoft-json": {
+      "version": "3.2.2",
+      "depth": 1,
       "source": "registry",
       "dependencies": {},
       "url": "https://packages.unity.com"


### PR DESCRIPTION
## Description

Update the Unity package lock to Newtonsoft JSON 3.2.2 and remove obsolete Unity metadata files for package-manager configuration files.

## Related Issue

Not applicable.

## Testing Done

Not run; metadata-only change.

## Screenshots

Not applicable.

## Breaking Changes

None.

---

- [ ] Code compiles (`npm run compile`)
- [ ] Tested locally against a Unity project
- [ ] No new warnings introduced

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rankupgames/codesmith/unity-cursor-toolkit/pr/24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789510552&installation_model_id=21488&pr_number=24&repository=rankupgames%2Funity-cursor-toolkit&return_to=https%3A%2F%2Fgithub.com%2Frankupgames%2Funity-cursor-toolkit%2Fpull%2F24&signature=471809bfb8dee87f400a8350d18969da1679034aa2c20b0dbf71f247e93a4125"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->